### PR TITLE
Support mdata variable for /root/.ssh/authorized_keys file

### DIFF
--- a/includes/90-root-authorized-keys.sh
+++ b/includes/90-root-authorized-keys.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Configure root ssh authorized_keys file if available via mdata
+
+if mdata-get root_authorized_keys 1>/dev/null 2>&1; then
+  install --directory --mode=700 /root/.ssh
+  echo "# This file is managed by mdata-get root_authorized_keys" \
+    > /root/.ssh/authorized_keys
+  mdata-get root_authorized_keys >> /root/.ssh/authorized_keys
+  chmod 644 /root/.ssh/authorized_keys
+fi


### PR DESCRIPTION
This script creates a .ssh folder with minimal permissions, if the directory already exists the permissions will be changed to 700. If the mdata variable `root_authorized_keys` the `authorized_keys` is cleared and a header is added. I also fix the file permissions to be sure we're using the minimal permissions required for `authorized_keys`.
