### PR TITLE
disable SSH service during zoneinit

### DIFF
--- a/includes/999-cleanup.sh
+++ b/includes/999-cleanup.sh
@@ -1,5 +1,9 @@
 # Copyright 2013, Joyent. Inc. All rights reserved.
 
+log "making sure that SSH service is enabled"
+
+/usr/sbin/svcadm enable ssh
+
 log "cleaning up"
 
 svccfg -s zoneinit 'setprop application/done = true'

--- a/zoneinit
+++ b/zoneinit
@@ -63,6 +63,10 @@ trap 'exit_handler "received exit status" $?' EXIT
 START_TIME=$(date +%s)
 log "(start)"
 
+log "temporarily disabling SSH"
+
+/usr/sbin/svcadm disable -t ssh
+
 # Pull in and execute all operations from the 'includes' directory
 for INC in ${ZONEINIT_INCLUDES}/*.sh
 do

--- a/zoneinit
+++ b/zoneinit
@@ -63,6 +63,9 @@ trap 'exit_handler "received exit status" $?' EXIT
 START_TIME=$(date +%s)
 log "(start)"
 
+log "disabling SSH service"
+/usr/sbin/svcadm disable ssh
+
 # Pull in and execute all operations from the 'includes' directory
 for INC in ${ZONEINIT_INCLUDES}/*.sh
 do


### PR DESCRIPTION
Having SSH briefly up during zoneinit confuses SSH-based provisioning systems (e.g. chef-provisioning with Joyent FOG plugin).
